### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ APIbase is a production MCP server that gives AI agents instant access to real-w
 
 **Built for AI agents, not humans.** Every tool is designed for autonomous discovery, authentication, and invocation via the [Model Context Protocol](https://modelcontextprotocol.io).
 
+<a href="https://glama.ai/mcp/servers/whiteknightonhorse/APIbase">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/whiteknightonhorse/APIbase/badge" alt="APIbase MCP server" />
+</a>
+
 ### Why agents use APIbase
 
 - **One MCP endpoint** — `https://apibase.pro/mcp` connects to 5 providers


### PR DESCRIPTION
This PR adds a badge for the [APIbase](https://glama.ai/mcp/servers/whiteknightonhorse/APIbase) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/whiteknightonhorse/APIbase">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/whiteknightonhorse/APIbase/badge" alt="APIbase MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.