### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Production MCP server that gives AI agents access to 373 real-world API tools th
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/whiteknightonhorse-apibase).
+
 ## Quick Start (30 seconds)
 
 ### Claude Desktop / Cursor / Windsurf


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/whiteknightonhorse-apibase)